### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/examples/Commerical/basic_dmz_spoke/versions.tf
+++ b/examples/Commerical/basic_dmz_spoke/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.36"
+      version = "~> 3.116"
     }
   }
 }

--- a/examples/Government/basic_dmz_spoke/versions.tf
+++ b/examples/Government/basic_dmz_spoke/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.36"
+      version = "~> 3.116"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,16 +3,16 @@
 
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = "~> 3.36"
+      version               = "~> 3.116"
       configuration_aliases = [azurerm.hub_network]
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"
-      version = "~> 1.0"
+      version = "~> 1.0.4"
     }
   }
 }


### PR DESCRIPTION
## Summary
Modernize version constraints to current standards.
### Changes
- Terraform `>= 1.3` → `>= 1.9`
- azurerm `~> 3.x` → `~> 3.116`
- azurenoopsutils → `~> 1.0.4`
- Updated examples and documentation
Closes #4