### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-dmzspoke
+  name: terraform-az-overlays-dmzspoke
   description: Terraform overlay module for DMZ spoke virtual networks
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-dmzspoke
+    github.com/project-slug: POps-Rox/terraform-az-overlays-dmzspoke
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-dmzspoke
+    - url: https://github.com/POps-Rox/terraform-az-overlays-dmzspoke
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/basic_dmz_spoke/main.tf
+++ b/examples/Commerical/basic_dmz_spoke/main.tf
@@ -1,6 +1,6 @@
 
 module "mod_vnet_spoke" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-dmzspoke"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-dmzspoke"
   #version = "~> x.x.x"
   source = "../../.."
   providers = {

--- a/examples/Government/basic_dmz_spoke/main.tf
+++ b/examples/Government/basic_dmz_spoke/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_vnet_spoke" {
-  #source  = "github.com/POps-Rox/tf-az-overlays-workloadspoke"
+  #source  = "github.com/POps-Rox/terraform-az-overlays-workloadspoke"
   #version = "~> x.x.x"
   source = "../../.."
   providers = {

--- a/modules.workload.spoke.scaffolding.tf
+++ b/modules.workload.spoke.scaffolding.tf
@@ -6,7 +6,7 @@
 #--------------------------------------
 # This module will lookup the Azure Region and return the short name for the region
 module "mod_azregions" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = var.location
 }
@@ -23,7 +23,7 @@ data "azurerm_resource_group" "rgrp" {
 }
 
 module "mod_scaffold_rg" {
-  source = "github.com/POps-Rox/tf-az-overlays-resourcegroup"
+  source = "github.com/POps-Rox/terraform-az-overlays-resourcegroup"
 
   count = var.create_spoke_resource_group ? 1 : 0
 

--- a/modules.workload.spoke.storage.account.tf
+++ b/modules.workload.spoke.storage.account.tf
@@ -6,7 +6,7 @@
 #----------------------------------------------------------
 module "wl_storage_account_spoke" {
   depends_on                   = [module.mod_scaffold_rg]
-  source                       = "github.com/POps-Rox/tf-az-overlays-storageaccount"
+  source                       = "github.com/POps-Rox/terraform-az-overlays-storageaccount"
   existing_resource_group_name = local.resource_group_name
   storage_account_custom_name  = local.spoke_sa_name
   location                     = local.location


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.