### PR TITLE
fix: restore providers.tf stub for standalone CI validation

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,10 @@
+# Provider configurations for standalone validation and CI
+# When used as a module, providers are passed by the caller via configuration_aliases
+provider "azurerm" {
+  features {}
+}
+
+provider "azurerm" {
+  alias = "hub_network"
+  features {}
+}


### PR DESCRIPTION
Post-merge fix. The fleet agent removed providers.tf assuming it was unused, but the module uses configuration_aliases which requires the stub. Restored with explanatory comment.